### PR TITLE
Rename project to tele-claude

### DIFF
--- a/PARSER_DESIGN.md
+++ b/PARSER_DESIGN.md
@@ -259,9 +259,9 @@ The delta-based approach handles this by:
 
 ## Files to Modify
 
-- `/Users/gavrix/Projects/tele-bot/parser.py` - Add color-based classification
-- `/Users/gavrix/Projects/tele-bot/session.py` - Handle SegmentUpdate actions
-- `/Users/gavrix/Projects/tele-bot/test_parser.py` - Add color-based tests
+- `/Users/gavrix/Projects/tele-claude/parser.py` - Add color-based classification
+- `/Users/gavrix/Projects/tele-claude/session.py` - Handle SegmentUpdate actions
+- `/Users/gavrix/Projects/tele-claude/test_parser.py` - Add color-based tests
 
 ## Segment Types
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# tele-bot
+# tele-claude
 
 A Telegram bot that connects forum topics to Claude Code CLI sessions.
 
@@ -36,8 +36,8 @@ A Telegram bot that connects forum topics to Claude Code CLI sessions.
 
 ```bash
 # Clone and install
-git clone https://github.com/gavrix/tele-bot.git
-cd tele-bot
+git clone https://github.com/gavrix/tele-claude.git
+cd tele-claude
 pip install -r requirements.txt
 
 # Configure

--- a/handlers.py
+++ b/handlers.py
@@ -14,7 +14,7 @@ from telegram.ext import ContextTypes
 import logging
 
 # Use standard logging - logger.py's setup_logging() will configure the handlers
-logger = logging.getLogger("tele-bot.handlers")
+logger = logging.getLogger("tele-claude.handlers")
 
 from config import GENERAL_TOPIC_ID
 from utils import get_project_folders

--- a/logger.py
+++ b/logger.py
@@ -58,7 +58,7 @@ def setup_logging() -> None:
     root_logger.addHandler(file_handler)
 
     # App logger for our own code
-    _app_logger = logging.getLogger("tele-bot")
+    _app_logger = logging.getLogger("tele-claude")
     _app_logger.setLevel(logging.DEBUG)
 
     # Log startup

--- a/session.py
+++ b/session.py
@@ -27,7 +27,7 @@ from logger import SessionLogger
 from diff_image import edit_to_image
 
 # Module logger (named _log to avoid collision with SessionLogger variables named 'logger')
-_log = logging.getLogger("tele-bot.session")
+_log = logging.getLogger("tele-claude.session")
 
 
 # Context window sizes by model (tokens)


### PR DESCRIPTION
## Summary
- Rename all references from `tele-bot` to `tele-claude` to match the new GitHub repo name
- Updates README title and clone instructions
- Updates file paths in PARSER_DESIGN.md
- Updates logger names in Python files

## Test plan
- [ ] Verify bot starts without import errors
- [ ] Check logs show `tele-claude` logger names

🤖 Generated with [Claude Code](https://claude.com/claude-code)