### PR TITLE
Add /help command

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -4,7 +4,7 @@ from telegram import Update
 from telegram.ext import Application, MessageHandler, CommandHandler, CallbackQueryHandler, filters
 
 from config import BOT_TOKEN
-from handlers import handle_new_topic, handle_callback, handle_message, handle_topic_created, handle_photo
+from handlers import handle_new_topic, handle_callback, handle_message, handle_topic_created, handle_photo, handle_help
 from logger import setup_logging
 
 # Configure logging - silent console, full file logging
@@ -27,6 +27,13 @@ def main() -> None:
     app.add_handler(CommandHandler(
         "new",
         handle_new_topic,
+        filters=filters.ChatType.SUPERGROUP
+    ))
+
+    # Handle /help command - show all available commands
+    app.add_handler(CommandHandler(
+        "help",
+        handle_help,
         filters=filters.ChatType.SUPERGROUP
     ))
 

--- a/commands.py
+++ b/commands.py
@@ -28,6 +28,12 @@ class SlashCommand:
 # Hard-coded universal commands - available in all sessions
 HARDCODED_COMMANDS: list[SlashCommand] = [
     SlashCommand(
+        name="help",
+        description="Show all available commands",
+        prompt="",  # Handled specially - doesn't go to Claude
+        is_contextual=False,
+    ),
+    SlashCommand(
         name="plan",
         description="Enter plan mode - explore and design before implementing",
         prompt="/plan",
@@ -158,3 +164,28 @@ def get_command_prompt(
             return cmd.prompt
 
     return None
+
+
+def get_help_message(contextual_commands: list[SlashCommand]) -> str:
+    """Generate help message listing all available commands.
+
+    Args:
+        contextual_commands: Project-specific commands for current session
+
+    Returns:
+        Formatted help message string (HTML)
+    """
+    lines = ["<b>Available Commands</b>\n"]
+
+    # Global commands section
+    lines.append("<b>Global:</b>")
+    for cmd in HARDCODED_COMMANDS:
+        lines.append(f"  /{cmd.name} - {cmd.description}")
+
+    # Contextual commands section (if any)
+    if contextual_commands:
+        lines.append("\n<b>Project:</b>")
+        for cmd in contextual_commands:
+            lines.append(f"  /{cmd.name} - {cmd.description}")
+
+    return "\n".join(lines)

--- a/handlers.py
+++ b/handlers.py
@@ -19,7 +19,7 @@ logger = logging.getLogger("tele-claude.handlers")
 from config import GENERAL_TOPIC_ID
 from utils import get_project_folders
 from session import sessions, start_session, send_to_claude, resolve_permission, interrupt_session
-from commands import get_command_prompt
+from commands import get_command_prompt, get_help_message
 
 
 async def handle_new_topic(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
@@ -208,6 +208,29 @@ async def handle_callback(update: Update, context: ContextTypes.DEFAULT_TYPE) ->
             return
 
     # Unknown callback - ignore
+
+
+async def handle_help(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    """Handle /help command - show all available commands."""
+    message = update.message
+    if message is None:
+        return
+
+    thread_id = message.message_thread_id
+    chat_id = message.chat_id
+
+    # Get contextual commands if in an active session
+    contextual_commands: list = []
+    if thread_id and thread_id in sessions:
+        contextual_commands = sessions[thread_id].contextual_commands
+
+    help_text = get_help_message(contextual_commands)
+    await context.bot.send_message(
+        chat_id=chat_id,
+        message_thread_id=thread_id,
+        text=help_text,
+        parse_mode="HTML"
+    )
 
 
 async def handle_photo(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:

--- a/test_commands.py
+++ b/test_commands.py
@@ -8,6 +8,7 @@ from commands import (
     HARDCODED_COMMANDS,
     load_contextual_commands,
     get_command_prompt,
+    get_help_message,
 )
 
 
@@ -185,7 +186,45 @@ class TestHardcodedCommands:
         names = {cmd.name for cmd in HARDCODED_COMMANDS}
         assert "compact" in names
 
+    def test_help_command_exists(self):
+        """Help command should exist in hard-coded commands."""
+        names = {cmd.name for cmd in HARDCODED_COMMANDS}
+        assert "help" in names
+
     def test_all_hardcoded_are_not_contextual(self):
         """All hard-coded commands should have is_contextual=False."""
         for cmd in HARDCODED_COMMANDS:
             assert cmd.is_contextual is False
+
+
+class TestGetHelpMessage:
+    """Tests for get_help_message()."""
+
+    def test_shows_global_commands(self):
+        """Help message should include global commands."""
+        result = get_help_message([])
+        assert "/help" in result
+        assert "/plan" in result
+        assert "/compact" in result
+        assert "<b>Global:</b>" in result
+
+    def test_shows_contextual_commands(self):
+        """Help message should include contextual commands when provided."""
+        contextual = [
+            SlashCommand("test", "Run tests", "pytest", True),
+            SlashCommand("lint", "Run linter", "ruff check", True),
+        ]
+        result = get_help_message(contextual)
+        assert "/test" in result
+        assert "/lint" in result
+        assert "<b>Project:</b>" in result
+
+    def test_no_project_section_when_empty(self):
+        """Help message should not show Project section when no contextual commands."""
+        result = get_help_message([])
+        assert "<b>Project:</b>" not in result
+
+    def test_returns_html_format(self):
+        """Help message should use HTML formatting."""
+        result = get_help_message([])
+        assert "<b>Available Commands</b>" in result


### PR DESCRIPTION
Adds a `/help` command that lists all available bot commands.

- Shows global commands (help, plan, compact, restart)
- Shows project-specific contextual commands when in an active session
- Includes tests for help message generation