### PR TITLE
Add chat authorization to restrict bot usage

### DIFF
--- a/config.py
+++ b/config.py
@@ -7,3 +7,11 @@ load_dotenv()
 BOT_TOKEN = os.getenv("BOT_TOKEN")
 PROJECTS_DIR = Path(os.getenv("PROJECTS_DIR", Path.home() / "Projects"))
 GENERAL_TOPIC_ID = 0
+
+# Authorized chat IDs - only these group chats can use the bot
+# Set via ALLOWED_CHATS env var as comma-separated Telegram chat IDs
+# Example: ALLOWED_CHATS=-1001234567890,-1009876543210
+_allowed_chats_str = os.getenv("ALLOWED_CHATS", "")
+ALLOWED_CHATS: set[int] = {
+    int(cid.strip()) for cid in _allowed_chats_str.split(",") if cid.strip()
+}


### PR DESCRIPTION
## Summary
- Add `ALLOWED_CHATS` environment variable to configure authorized chat IDs
- Add authorization checks to all handlers (messages, photos, callbacks, commands)
- Silently reject and log unauthorized access attempts
- Backwards compatible: if `ALLOWED_CHATS` is not set, all chats are allowed