### PR TITLE
Add per-session model switching with /model across Telegram and Discord

### DIFF
--- a/commands.py
+++ b/commands.py
@@ -45,6 +45,12 @@ HARDCODED_COMMANDS: list[SlashCommand] = [
         prompt="/compact",
         is_contextual=False,
     ),
+    SlashCommand(
+        name="model",
+        description="Switch model for this session",
+        prompt="",  # Handled specially - doesn't go to Claude
+        is_contextual=False,
+    ),
 ]
 
 
@@ -166,26 +172,38 @@ def get_command_prompt(
     return None
 
 
-def get_help_message(contextual_commands: list[SlashCommand]) -> str:
+def get_help_message(contextual_commands: list[SlashCommand], current_model: Optional[str] = None) -> str:
     """Generate help message listing all available commands.
 
     Args:
         contextual_commands: Project-specific commands for current session
+        current_model: Currently active model name for this session
 
     Returns:
         Formatted help message string (HTML)
     """
+    from config import AVAILABLE_MODELS
+
     lines = ["<b>Available Commands</b>\n"]
 
     # Global commands section
     lines.append("<b>Global:</b>")
     for cmd in HARDCODED_COMMANDS:
-        lines.append(f"  /{cmd.name} - {cmd.description}")
+        if cmd.name == "model":
+            lines.append(f"  /{cmd.name} &lt;name&gt; - {cmd.description}")
+        else:
+            lines.append(f"  /{cmd.name} - {cmd.description}")
 
     # Contextual commands section (if any)
     if contextual_commands:
         lines.append("\n<b>Project:</b>")
         for cmd in contextual_commands:
             lines.append(f"  /{cmd.name} - {cmd.description}")
+
+    # Model info
+    lines.append(f"\n<b>Current model:</b> {current_model or 'default'}")
+    lines.append("<b>Available models:</b>")
+    for m in AVAILABLE_MODELS:
+        lines.append(f"  <code>{m}</code>")
 
     return "\n".join(lines)

--- a/config.py
+++ b/config.py
@@ -39,6 +39,15 @@ DISCORD_ALLOWED_GUILDS: set[int] = {
 }
 
 
+# --- Model Config ---
+CLAUDE_MODEL = os.getenv("CLAUDE_MODEL") or None  # e.g. "claude-opus-4-6"
+AVAILABLE_MODELS = [
+    "claude-opus-4-6",
+    "claude-opus-4-5-20251101",
+    "claude-sonnet-4-5-20251101",
+    "claude-sonnet-4-20250514",
+]
+
 # --- Task Injection API ---
 TASK_API_HOST = os.getenv("TASK_API_HOST", "127.0.0.1")
 TASK_API_PORT = _env_int("TASK_API_PORT", 9111)

--- a/core/session_actor.py
+++ b/core/session_actor.py
@@ -89,6 +89,9 @@ class SessionActor:
             contextual = getattr(self.claude_session, "contextual_commands", [])
             command_prompt = get_command_prompt(command_name, contextual)
             if command_prompt is not None:
+                if command_prompt == "":
+                    # Command handled by platform (e.g. /help, /model) - skip
+                    return
                 prompt = command_prompt
 
         self.stats.message_count += 1

--- a/platforms/telegram/handlers.py
+++ b/platforms/telegram/handlers.py
@@ -482,22 +482,8 @@ async def _handle_message_impl(update: Update, context: ContextTypes.DEFAULT_TYP
             command_part = text.split()[0]
             command_name = command_part.lstrip("/").split("@")[0]
 
-            # Commands handled locally (not forwarded to Claude)
-            if command_name == "help":
-                help_text = get_help_message(
-                    session.contextual_commands,
-                    session.model_override or CLAUDE_MODEL,
-                )
-                await context.bot.send_message(
-                    chat_id=message.chat_id,
-                    message_thread_id=thread_id,
-                    text=help_text,
-                    parse_mode="HTML",
-                )
-                return
-
-            if command_name == "model":
-                await _handle_model_command(text, session, context.bot, message.chat_id, thread_id)
+            # Commands handled by CommandHandlers (avoid duplicate replies).
+            if command_name in {"help", "model"}:
                 return
 
             # Look up the command

--- a/platforms/telegram/handlers.py
+++ b/platforms/telegram/handlers.py
@@ -338,8 +338,9 @@ async def handle_model(update: Update, context: ContextTypes.DEFAULT_TYPE) -> No
 
     thread_id = message.message_thread_id
     chat_id = message.chat_id
+    effective_thread_id = thread_id if thread_id else GENERAL_TOPIC_ID
 
-    if not thread_id or thread_id not in sessions:
+    if effective_thread_id not in sessions:
         await context.bot.send_message(
             chat_id=chat_id,
             message_thread_id=thread_id,
@@ -348,7 +349,7 @@ async def handle_model(update: Update, context: ContextTypes.DEFAULT_TYPE) -> No
         return
 
     await _handle_model_command(
-        message.text or "", sessions[thread_id], context.bot, chat_id, thread_id
+        message.text or "", sessions[effective_thread_id], context.bot, chat_id, thread_id
     )
 
 

--- a/platforms/telegram/runner.py
+++ b/platforms/telegram/runner.py
@@ -24,7 +24,7 @@ def run_global() -> None:
     from config import BOT_TOKEN
     from platforms.telegram.handlers import (
         handle_new_topic, handle_callback, handle_message,
-        handle_topic_created, handle_photo, handle_help
+        handle_topic_created, handle_photo, handle_help, handle_model
     )
 
     setup_logging()
@@ -73,6 +73,13 @@ def run_global() -> None:
         filters=filters.ChatType.SUPERGROUP
     ))
 
+    # Handle /model command
+    app.add_handler(CommandHandler(
+        "model",
+        handle_model,
+        filters=filters.ChatType.SUPERGROUP
+    ))
+
     # Handle inline keyboard button clicks
     app.add_handler(CallbackQueryHandler(handle_callback))
 
@@ -102,7 +109,7 @@ def run_local(local_cwd: Path) -> None:
     """
     from platforms.telegram.handlers import (
         handle_callback, handle_message, handle_photo,
-        handle_help, is_authorized_chat
+        handle_help, handle_model, is_authorized_chat
     )
     from session import start_session_local
 
@@ -186,6 +193,13 @@ def run_local(local_cwd: Path) -> None:
     app.add_handler(CommandHandler(
         "help",
         handle_help,
+        filters=filters.ChatType.SUPERGROUP
+    ))
+
+    # Handle /model command
+    app.add_handler(CommandHandler(
+        "model",
+        handle_model,
         filters=filters.ChatType.SUPERGROUP
     ))
 

--- a/session.py
+++ b/session.py
@@ -28,6 +28,7 @@ from claude_agent_sdk.types import (
     TextBlock, ToolUseBlock, ThinkingBlock, ToolResultBlock
 )
 
+import config
 from config import PROJECTS_DIR
 from logger import SessionLogger
 from diff_image import edit_to_image
@@ -238,6 +239,7 @@ class ClaudeSession:
     pending_image_path: Optional[str] = None  # Buffered image waiting for prompt
     contextual_commands: list = field(default_factory=list)  # Project-specific slash commands
     sandboxed: bool = False  # If True, only load project settings (no ~/.claude/)
+    model_override: Optional[str] = None  # Per-session model override (via /model command)
 
     def get_platform(self) -> Optional[PlatformClient]:
         """Get platform client, creating from bot if needed (backwards compat)."""
@@ -949,6 +951,7 @@ async def send_to_claude(thread_id: int, prompt: str, bot: Optional[Bot] = None)
 
         # Configure options - use permission handler for interactive tool approval
         options = ClaudeAgentOptions(
+            model=session.model_override or config.CLAUDE_MODEL,
             allowed_tools=[],  # Empty - let can_use_tool handle all permissions
             can_use_tool=create_permission_handler(session),
             permission_mode="acceptEdits",


### PR DESCRIPTION
## Summary
- Add a global `/model` command to switch Claude model per session.
- Add model configuration in `config.py` (`CLAUDE_MODEL` and `AVAILABLE_MODELS`).
- Store per-session `model_override` and pass the selected model to `ClaudeAgentOptions`.
- Update `/help` output to include the current model and list available models.
- Support `/model` handling in both active and newly created session flows for Telegram and Discord.
- Prevent duplicate `/help` and `/model` replies by avoiding double-processing between command handlers and text handlers.
- Ensure platform-handled commands are not forwarded to Claude as prompts.

## Files changed
- `commands.py`, `config.py`, `session.py`, `core/session_actor.py`
- `platforms/telegram/handlers.py`, `platforms/telegram/listener.py`, `platforms/telegram/runner.py`
- `platforms/discord/handlers.py`

## Testing
- Not run in this branch.