### PR TITLE
feat: /model command for per-session model switching

### DIFF
--- a/commands.py
+++ b/commands.py
@@ -45,6 +45,12 @@ HARDCODED_COMMANDS: list[SlashCommand] = [
         prompt="/compact",
         is_contextual=False,
     ),
+    SlashCommand(
+        name="model",
+        description="Show or switch the Claude model",
+        prompt="",  # Handled specially - doesn't go to Claude
+        is_contextual=False,
+    ),
 ]
 
 


### PR DESCRIPTION
## Summary
- `/model` lists available models from SDK's `get_server_info()` at runtime
- `/model <name>` switches model for the current session only (other sessions unaffected)
- Accepts any alias (`default`, `sonnet`, `haiku`, `opus`, `opusplan`) or full model ID — SDK validates on next query
- Supersedes #33 with a cleaner approach: runtime discovery instead of hardcoded lists, per-session state on `ClaudeSession` instead of duplicated code

## Changes
- **`session.py`**: `model_override` field on `ClaudeSession`, `_get_available_models()` with retry-safe caching, `handle_model_command()`, `build_options()` uses override
- **`core/session_actor.py`**: Intercepts `/model` before Claude, delegates to handler
- **`commands.py`**: `/model` in `HARDCODED_COMMANDS` for autocompletion + `/help`

## Test plan
- [x] `pyright` — 0 errors
- [x] `pytest` — 116 passing
- [x] Manual: `/model` shows list with current marked
- [x] Manual: `/model haiku` switches, confirmed via model self-identification
- [x] Manual: `/model default` switches back to Opus 4.6
- [x] Manual: `/model opus` works (not in `get_server_info()` but SDK accepts it)
- [x] Confirmed per-session isolation — switching in one topic doesn't affect others

🤖 Generated with [Claude Code](https://claude.com/claude-code)